### PR TITLE
고친 곳 : 프로젝트 제목과 설명

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -153,7 +153,10 @@
   {{ project.name }}
 </h5>
 
-            <p class="card-text">{{ project.description }}</p>
+           <p class="card-text" style="word-wrap: break-word; overflow-wrap: break-word; white-space: normal;">
+  {{ project.description }}
+</p>
+
             <div class="d-flex align-items-center mb-2">
               <div class="member-avatar"><i class="bi bi-people"></i></div>
               <span class="ms-2">{{ project.members|length }} members</span>


### PR DESCRIPTION
프로젝트 제목, 설명란이 길 경우 칸 밖으로 나가는 현상을 고침